### PR TITLE
Fix Error no new Security Groups

### DIFF
--- a/3-infra-con-terraform/13-crear-servidor-4/main.tf
+++ b/3-infra-con-terraform/13-crear-servidor-4/main.tf
@@ -5,6 +5,14 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# ----------------------------------------------------
+# Data Source para obtener el ID de la VPC por defecto
+# ----------------------------------------------------
+data "aws_vpc" "default" {
+  default = true
+}
+
+
 # ---------------------------------------
 # Define una instancia EC2 con AMI Ubuntu
 # ---------------------------------------
@@ -26,8 +34,8 @@ resource "aws_instance" "mi_servidor" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"

--- a/3-infra-con-terraform/14-crear-servidor-5/main.tf
+++ b/3-infra-con-terraform/14-crear-servidor-5/main.tf
@@ -5,6 +5,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# ----------------------------------------------------
+# Data Source para obtener el ID de la VPC por defecto
+# ----------------------------------------------------
+data "aws_vpc" "default" {
+  default = true
+}
+
 # ---------------------------------------
 # Define una instancia EC2 con AMI Ubuntu
 # ---------------------------------------
@@ -30,8 +37,8 @@ resource "aws_instance" "mi_servidor" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"

--- a/3-infra-con-terraform/20-terraform-outputs/main.tf
+++ b/3-infra-con-terraform/20-terraform-outputs/main.tf
@@ -5,6 +5,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# ----------------------------------------------------
+# Data Source para obtener el ID de la VPC por defecto
+# ----------------------------------------------------
+data "aws_vpc" "default" {
+  default = true
+}
+
 # ---------------------------------------
 # Define una instancia EC2 con AMI Ubuntu
 # ---------------------------------------
@@ -30,8 +37,8 @@ resource "aws_instance" "mi_servidor" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"

--- a/3-infra-con-terraform/20-terraform-outputs/solucion-ejercicio/main.tf
+++ b/3-infra-con-terraform/20-terraform-outputs/solucion-ejercicio/main.tf
@@ -5,6 +5,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# ----------------------------------------------------
+# Data Source para obtener el ID de la VPC por defecto
+# ----------------------------------------------------
+data "aws_vpc" "default" {
+  default = true
+}
+
 # ---------------------------------------
 # Define una instancia EC2 con AMI Ubuntu
 # ---------------------------------------
@@ -30,8 +37,8 @@ resource "aws_instance" "mi_servidor" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"

--- a/3-infra-con-terraform/22-load-balancer-1/main.tf
+++ b/3-infra-con-terraform/22-load-balancer-1/main.tf
@@ -5,6 +5,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# ----------------------------------------------------
+# Data Source para obtener el ID de la VPC por defecto
+# ----------------------------------------------------
+data "aws_vpc" "default" {
+  default = true
+}
+
 # ---------------------------------------
 # Define una instancia EC2 con AMI Ubuntu
 # ---------------------------------------
@@ -49,8 +56,8 @@ resource "aws_instance" "servidor_2" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"

--- a/3-infra-con-terraform/22-load-balancer-1/outputs.tf
+++ b/3-infra-con-terraform/22-load-balancer-1/outputs.tf
@@ -1,4 +1,9 @@
-output "dns_publica" {
-  description = "DNS pública del servidor"
-  value       = "http://${aws_instance.mi_servidor.public_dns}:8080"
+output "dns_publica_server1" {
+  description = "DNS pública del servidor 1"
+  value       = "http://${aws_instance.servidor_1.public_dns}:8080"
+}
+
+output "dns_publica_server2" {
+  description = "DNS pública del servidor 2"
+  value       = "http://${aws_instance.servidor_2.public_dns}:8080"
 }

--- a/3-infra-con-terraform/23-load-balancer-2/main.tf
+++ b/3-infra-con-terraform/23-load-balancer-2/main.tf
@@ -5,6 +5,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# ----------------------------------------------------
+# Data Source para obtener el ID de la VPC por defecto
+# ----------------------------------------------------
+data "aws_vpc" "default" {
+  default = true
+}
+
 # -----------------------------------------------
 # Data source que obtiene el id del AZ eu-west-1a
 # -----------------------------------------------
@@ -65,8 +72,8 @@ resource "aws_instance" "servidor_2" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"

--- a/3-infra-con-terraform/24-load-balancer-3/main.tf
+++ b/3-infra-con-terraform/24-load-balancer-3/main.tf
@@ -5,6 +5,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# ----------------------------------------------------
+# Data Source para obtener el ID de la VPC por defecto
+# ----------------------------------------------------
+data "aws_vpc" "default" {
+  default = true
+}
+
 # -----------------------------------------------
 # Data source que obtiene el id del AZ eu-west-1a
 # -----------------------------------------------
@@ -65,8 +72,8 @@ resource "aws_instance" "servidor_2" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"
@@ -92,7 +99,7 @@ resource "aws_lb" "alb" {
 # ------------------------------------
 resource "aws_security_group" "alb" {
   name = "alb-sg"
-
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 80 desde el exterior"

--- a/3-infra-con-terraform/25-load-balancer-4/main.tf
+++ b/3-infra-con-terraform/25-load-balancer-4/main.tf
@@ -65,8 +65,8 @@ resource "aws_instance" "servidor_2" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
-
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 8080 desde el exterior"
@@ -92,7 +92,7 @@ resource "aws_lb" "alb" {
 # ------------------------------------
 resource "aws_security_group" "alb" {
   name = "alb-sg"
-
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 80 desde el exterior"

--- a/3-infra-con-terraform/26-load-balancer-5/main.tf
+++ b/3-infra-con-terraform/26-load-balancer-5/main.tf
@@ -65,7 +65,8 @@ resource "aws_instance" "servidor_2" {
 # Define un grupo de seguridad con acceso al puerto 8080
 # ------------------------------------------------------
 resource "aws_security_group" "mi_grupo_de_seguridad" {
-  name = "primer-servidor-sg"
+  name   = "primer-servidor-sg"
+  vpc_id = data.aws_vpc.default.id
 
   ingress {
     security_groups = [aws_security_group.alb.id]
@@ -91,8 +92,8 @@ resource "aws_lb" "alb" {
 # Security group para el Load Balancer
 # ------------------------------------
 resource "aws_security_group" "alb" {
-  name = "alb-sg"
-
+  name   = "alb-sg"
+  vpc_id = data.aws_vpc.default.id
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Acceso al puerto 80 desde el exterior"


### PR DESCRIPTION
This PR solve the error: **Fix Error Error: with the retirement of EC2-Classic no new Security Groups can be created without referencing a VPC**

- Add data to retrive default vpc
- add default vpc id to ELB